### PR TITLE
Fix CallableCopy test

### DIFF
--- a/test/borrowed_ptr.cc
+++ b/test/borrowed_ptr.cc
@@ -332,7 +332,7 @@ TEST(BorrowTest, CallableCopy) {
   Borrowable<std::string> s("hello world");
 
   auto callable = s.Borrow([&]() {
-    EXPECT_EQ(s.borrows(), 1);
+    EXPECT_EQ(s.borrows(), 2);
   });
 
   EXPECT_EQ(s.borrows(), 1);


### PR DESCRIPTION
For now `CallableCopy` test fails on Ubuntu with the following output:
![12](https://user-images.githubusercontent.com/68085133/163691564-ea487d94-b54f-455b-8412-10f9b2a0f911.png)

```
Borrowable<std::string> s("hello world");

auto callable = s.Borrow([&]() {
  EXPECT_EQ(s.borrows(), 2);
});

EXPECT_EQ(s.borrows(), 1);

{
   auto copy = callable;

   EXPECT_EQ(s.borrows(), 2);

   copy();
}
 ``` 
If I understand correctly , when we call copy() => lambda will be invoked and we should expect value `2` from `s.borrows()`. Am I missing something?